### PR TITLE
fix some bugs in program.

### DIFF
--- a/gisaid_downloader.py
+++ b/gisaid_downloader.py
@@ -462,7 +462,8 @@ argp.add_argument('-dr', '--download_ranks', default=[2, ], nargs='+', type=int,
 
 if __name__ == '__main__':
     args = argp.parse_args()
-    os.chdir(os.path.split(__file__)[0])
+    #os.chdir(os.path.split(__file__)[0])
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
     spider_loop(
         name=args.name[0],
         password=args.password[0],

--- a/parse_acnums.py
+++ b/parse_acnums.py
@@ -90,7 +90,7 @@ class AcNumAnalysis:
             to_return = [self.ac_nums[0], self.ac_nums[0] + self.default_num - 1]
             self.ac_nums[0] = self.ac_nums[0] + self.default_num
             print('\rOutput {} Accession Nums'.format(str(self.default_num)), end='')
-            return num_pairs_to_str(to_return)
+            return num_pairs_to_str(to_return), self.default_num
         for i in range(int(len(self.ac_nums) / 2)):
             new_num_pair = [self.ac_nums[2 * i], self.ac_nums[2 * i + 1]]
             sub = new_num_pair[1] - new_num_pair[0] + 1
@@ -130,7 +130,9 @@ class AcNumAnalysis:
             if not current_num_pair:
                 current_num_pair = [self.ac_nums[2*i], self.ac_nums[2*i+1]]
             else:
-                if self.ac_nums[2*i] == current_num_pair[1] + 1:
+                count = self.ac_nums[2*i+1] - current_num_pair[0] +1
+                if self.ac_nums[2*i] == current_num_pair[1] + 1 and count <= self.default_num:
+                    # continues and in default numbers.
                     current_num_pair[1] = self.ac_nums[2*i+1]
                 else:
                     new_ac_nums += current_num_pair


### PR DESCRIPTION
你好。发现程序中存在几个bug，已经做了修复。具体如下：

1. 提供csv编号文件，但是如果该文件包含的编号数目超过了阈值，例如`EPI_ISL_17207420-EPI_ISL_17213420`。则`parse_acnums.AcNumAnalysis.zip_ac_nums`会把它们合并成一个，例如`17207420-17213420`。这样超出了阈值。我修改这个函数。如果acc数目超过了阈值，则不再合并连续的编号，重新作为一个新的编号。
2. `parse_acnums.AcNumAnalysis.analysis`函数。当某一对任务的编号数目超过阈值时，会返回阈值前的样本数目。但是`return`只返回了字符串，没有返回数目。这是数据中有些是`E`的错误来源。程序后续跳过了这部分数据。最终导致了对于某个任务，如果其编号数目超过了阈值，则程序只获取最后的阈值内的数据。我修改了step 1，因此这部分理论上不会执行。保险起见，我也修改了这部分的返回值。
3. 在linux系列系统测试，发现`gisaid_downloader.py`的工作目录为空。所以我修改了作为主程序执行时，切换工作目录的地方。

我并未测试在win下导致的影响。